### PR TITLE
Encoded a url parameter

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,7 +56,7 @@ use ExternalModules\ExternalModules;
     <?php
     $project_id = (int)$_GET['pid'];
     $privacy = $module->getProjectSetting('privacy',$project_id);
-    $report = htmlentities($_GET['report'],ENT_QUOTES);
+    $report = urlencode($_GET['report']);
     if(!empty($report)){
         $report = "&report=".$report;
     }


### PR DESCRIPTION
@knil-maloon, please test this before merging it.  I believe this is the correct way to escape the report parameter in this case.  I was using this case as an example to test the scan script, and figured I might as well share this PR.